### PR TITLE
Interactive flow: remove unnecessary homeDomain prop

### DIFF
--- a/examples/SEP-24/src/main/kotlin/org/stellar/walletsdk/Main.kt
+++ b/examples/SEP-24/src/main/kotlin/org/stellar/walletsdk/Main.kt
@@ -1,8 +1,5 @@
 package org.stellar.walletsdk
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import java.math.BigDecimal
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
@@ -66,12 +63,7 @@ suspend fun main() {
 
   // Start interactive deposit
   val deposit =
-    anchor.getInteractiveDeposit(
-      account.publicKeyString,
-      homeDomain = "testanchor.stellar.org",
-      assetCode = "SRT",
-      authToken = token
-    )
+    anchor.getInteractiveDeposit(account.publicKeyString, assetCode = "SRT", authToken = token)
 
   // Request user input
   println("Additional user info is required for the deposit, please visit: ${deposit.url}")
@@ -95,12 +87,7 @@ suspend fun main() {
 
   // Start interactive withdrawal
   val withdrawal =
-    anchor.getInteractiveWithdrawal(
-      account.publicKeyString,
-      homeDomain = "testanchor.stellar.org",
-      assetCode = "SRT",
-      authToken = token
-    )
+    anchor.getInteractiveWithdrawal(account.publicKeyString, assetCode = "SRT", authToken = token)
 
   // Request user input
   println("Additional user info is required for the withdrawal, please visit: ${withdrawal.url}")

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/Anchor.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/Anchor.kt
@@ -116,7 +116,6 @@ class Anchor(
    * for depositing funds
    * @param fundsAccountAddress optional Stellar address of the account for depositing funds, if
    * different from the account address
-   * @param homeDomain home domain of the anchor
    * @param assetCode Asset code to deposit
    * @param authToken Auth token from the anchor (account's authentication using SEP-10)
    *
@@ -129,7 +128,6 @@ class Anchor(
   suspend fun getInteractiveDeposit(
     accountAddress: String,
     fundsAccountAddress: String? = null,
-    homeDomain: String,
     assetCode: String,
     authToken: String,
   ): InteractiveFlowResponse {
@@ -154,7 +152,6 @@ class Anchor(
    * for withdrawing funds
    * @param fundsAccountAddress optional Stellar address of the account for withdrawing funds, if
    * different from the account address
-   * @param homeDomain home domain of the anchor
    * @param assetCode Asset code to deposit
    * @param authToken Auth token from the anchor (account's authentication using SEP-10)
    * @param extraFields Additional information to pass to the anchor
@@ -169,7 +166,6 @@ class Anchor(
   suspend fun getInteractiveWithdrawal(
     accountAddress: String,
     fundsAccountAddress: String? = null,
-    homeDomain: String,
     assetCode: String,
     authToken: String,
     extraFields: Map<String, Any>? = null,

--- a/wallet-sdk/src/test/kotlin/org/stellar/walletsdk/AnchorTest.kt
+++ b/wallet-sdk/src/test/kotlin/org/stellar/walletsdk/AnchorTest.kt
@@ -66,7 +66,6 @@ internal class AnchorTest {
         anchor.getInteractiveDeposit(
           accountAddress = ADDRESS_ACTIVE,
           assetCode = ANCHOR_ASSET_CODE,
-          homeDomain = ANCHOR_HOME_DOMAIN,
           authToken = authToken,
         )
       }
@@ -88,7 +87,6 @@ internal class AnchorTest {
           accountAddress = ADDRESS_ACTIVE,
           fundsAccountAddress = ADDRESS_ACTIVE_TWO,
           assetCode = ANCHOR_ASSET_CODE,
-          homeDomain = ANCHOR_HOME_DOMAIN,
           authToken = authToken,
         )
       }
@@ -113,7 +111,6 @@ internal class AnchorTest {
         anchor.getInteractiveWithdrawal(
           accountAddress = ADDRESS_ACTIVE,
           assetCode = ANCHOR_ASSET_CODE,
-          homeDomain = ANCHOR_HOME_DOMAIN,
           authToken = authToken,
         )
       }
@@ -135,7 +132,6 @@ internal class AnchorTest {
           accountAddress = ADDRESS_ACTIVE,
           fundsAccountAddress = ADDRESS_ACTIVE_TWO,
           assetCode = ANCHOR_ASSET_CODE,
-          homeDomain = ANCHOR_HOME_DOMAIN,
           authToken = authToken,
         )
       }


### PR DESCRIPTION
`homeDomain` prop is already passed to `Anchor`. No need to pass it again.