### PR TITLE
[ANCHOR-305] Support native asset get info

### DIFF
--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/toml/Data.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/toml/Data.kt
@@ -3,6 +3,8 @@ package org.stellar.walletsdk.toml
 import io.ktor.http.*
 import org.stellar.sdk.Network
 import org.stellar.walletsdk.asset.IssuedAssetId
+import org.stellar.walletsdk.asset.NativeAssetId
+import org.stellar.walletsdk.asset.StellarAssetId
 import org.stellar.walletsdk.exception.ValidationException
 import shadow.com.google.gson.annotations.SerializedName
 
@@ -122,7 +124,7 @@ data class InfoValidator(
 
 data class InfoCurrency(
   @SerializedName("code") val code: String,
-  @SerializedName("issuer") val issuer: String,
+  @SerializedName("issuer") val issuer: String?,
   @SerializedName("code_template") val codeTemplate: String?,
   @SerializedName("status") val status: String?,
   @SerializedName("display_decimals") val displayDecimals: Int?,
@@ -147,7 +149,12 @@ data class InfoCurrency(
 ) {
   private val myCode = code
   private val myIssuer = issuer
-  val assetId: IssuedAssetId = IssuedAssetId(myCode, myIssuer)
+  val assetId: StellarAssetId =
+    when {
+      myCode == "native" && myIssuer == null -> NativeAssetId
+      myCode != "native" && myIssuer != null -> IssuedAssetId(myCode, myIssuer)
+      else -> throw ValidationException("Invalid asset code and issuer pair: $myCode, $myIssuer")
+    }
 }
 
 data class InfoServices(

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/toml/ParseToml.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/toml/ParseToml.kt
@@ -48,7 +48,7 @@ fun parseToml(toml: Map<String, Any>): TomlInfo {
       InfoCurrency(
         code = it["code"].toString(),
         codeTemplate = it["code_template"]?.toString(),
-        issuer = it["issuer"].toString(),
+        issuer = it["issuer"]?.toString(),
         status = it["status"]?.toString(),
         displayDecimals = it["display_decimals"]?.toString()?.toInt(),
         name = it["name"]?.toString(),

--- a/wallet-sdk/src/test/kotlin/org/stellar/walletsdk/anchor/GetInfoTest.kt
+++ b/wallet-sdk/src/test/kotlin/org/stellar/walletsdk/anchor/GetInfoTest.kt
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.assertThrows
 import org.stellar.walletsdk.ADDRESS_ACTIVE
 import org.stellar.walletsdk.AUTH_HOME_DOMAIN
 import org.stellar.walletsdk.TestWallet
+import org.stellar.walletsdk.asset.IssuedAssetId
+import org.stellar.walletsdk.asset.NativeAssetId
 import org.stellar.walletsdk.helpers.mapFromTomlFile
 import org.stellar.walletsdk.toml.parseToml
 
@@ -35,9 +37,11 @@ internal class GetInfoTest {
   }
 
   @Test
-  fun `currency should have assetId`() {
-    val currency = toml.currencies?.get(0)
+  fun `currencies should have assetId`() {
+    val assetIds = toml.currencies?.map { it.assetId }
 
-    assertNotNull(currency?.assetId)
+    val srt = IssuedAssetId("SRT", "GCDNJUBQSX7AJWLJACMJ7I4BC3Z47BQUTMHEICZLE6MU4KQBRYG5JY6B")
+    val native = NativeAssetId
+    assert(assetIds?.containsAll(setOf(srt, native)) == true)
   }
 }

--- a/wallet-sdk/src/test/resources/stellar.toml
+++ b/wallet-sdk/src/test/resources/stellar.toml
@@ -16,6 +16,13 @@ status = "test"
 is_asset_anchored = false
 desc = "Stellar Reference Token (SRT) is an asset issued on testnet and is used as an anchored asset for this reference server for demonstration and testing purposes."
 
+[[CURRENCIES]]
+code = "native"
+status = "test"
+is_asset_anchored = false
+anchor_asset_type = "crypto"
+desc = "XLM, the native token of the Stellar network."
+
 [DOCUMENTATION]
 ORG_NAME = "Stellar Development Foundation"
 ORG_URL = "https://stellar.org"


### PR DESCRIPTION
I discovered in my testing of AP that trying to fetch the history of XLM transactions crashes with this error:
```
org.stellar.walletsdk.exception.AssetNotSupportedException: Asset org.stellar.walletsdk.asset.NativeAssetId@1823b9c4 is not supported

	at org.stellar.walletsdk.anchor.Anchor.getHistory-PL2Erck(Anchor.kt:179)
	at org.stellar.walletsdk.anchor.Anchor.getHistory-PL2Erck$default(Anchor.kt:170)
```

This PR adds support for the native asset in the get info endpoint.