### PR TITLE
[WAL-881] Add default implementation of domain http signer

### DIFF
--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/auth/WalletSigner.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/auth/WalletSigner.kt
@@ -1,5 +1,14 @@
 package org.stellar.walletsdk.auth
 
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.stellar.sdk.Network
 import org.stellar.sdk.Transaction
 import org.stellar.walletsdk.horizon.AccountKeyPair
 import org.stellar.walletsdk.horizon.PublicKeyPair
@@ -31,6 +40,46 @@ interface WalletSigner {
       account: AccountKeyPair
     ): Transaction {
       throw NotImplementedError("This signer can't sign transaction with domain")
+    }
+  }
+
+  /**
+   * Wallet signer that supports signing with a client domain using standard [SigningData] request
+   * and response type.
+   *
+   * @constructor Create empty Json http signer
+   * @property url url to which requests should be made
+   * @property requestTransformer optional transformer of the default request. Can be used for
+   *   authentication purposes, etc.
+   */
+  class DomainSigner(
+    val url: String,
+    val requestTransformer: HttpRequestBuilder.() -> Unit = {}
+  ) : DefaultSigner() {
+    val client = HttpClient() { install(ContentNegotiation) { json() } }
+
+    @Serializable
+    data class SigningData(
+      val transaction: String,
+      @SerialName("network_passphrase") val networkPassphrase: String
+    )
+
+    override suspend fun signWithDomainAccount(
+      transactionXDR: String,
+      networkPassPhrase: String,
+      account: AccountKeyPair
+    ): Transaction {
+      val response: SigningData =
+        client
+          .post(url) {
+            contentType(ContentType.Application.Json)
+            setBody(SigningData(transactionXDR, networkPassPhrase))
+            requestTransformer()
+          }
+          .body()
+
+      return Transaction.fromEnvelopeXdr(response.transaction, Network(networkPassPhrase))
+        as Transaction
     }
   }
 }


### PR DESCRIPTION
With this change, wallets would be able to implement client_domain signing as simply as creating new instance of the implementation
```kotlin
anchor
    .auth()
    .authenticate(
      wallet.stellar().account().createKeyPair(),
      WalletSigner.DomainSigner("https://demo-wallet-server.stellar.org/sign"),
      clientDomain = "demo-wallet-server.stellar.org"
    )
```
