### PR TITLE
[WAL-941] Deprecate formatted classes

### DIFF
--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/Data.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/Data.kt
@@ -107,7 +107,10 @@ data class NativeAssetDefault(
   val assetIssuer: String,
 )
 
-@Deprecated("Formatted classes are to be removed. Use rawOperation instead", replaceWith = ReplaceWith("this.rawOperation"))
+@Deprecated(
+  "Formatted classes are to be removed. Use rawOperation instead",
+  replaceWith = ReplaceWith("this.rawOperation")
+)
 data class WalletOperation<T>(
   val id: String,
   val date: String,

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/Data.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/Data.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 import org.stellar.sdk.requests.RequestBuilder
 import org.stellar.walletsdk.asset.AssetId
 
+@Deprecated("Formatted classes are to be removed")
 data class AccountInfo(
   val publicKey: String,
   val assets: List<FormattedAsset>,
@@ -20,6 +21,7 @@ data class AccountInfo(
  */
 data class AccountThreshold(val low: Int, val medium: Int, val high: Int)
 
+@Deprecated("Formatted classes are to be removed")
 enum class AssetType(val type: String) {
   NATIVE("native"),
   ALPHANUM_4("credit_alphanum4"),
@@ -27,6 +29,7 @@ enum class AssetType(val type: String) {
   LIQUIDITY_POOL("liquidity_pool_shares")
 }
 
+@Deprecated("Formatted classes are to be removed")
 data class CachedAsset(
   val id: String,
   val homeDomain: String?,
@@ -35,6 +38,7 @@ data class CachedAsset(
   val amount: String?
 )
 
+@Deprecated("Formatted classes are to be removed")
 data class FormattedAsset(
   val id: String,
   val homeDomain: String?,
@@ -48,11 +52,13 @@ data class FormattedAsset(
   val sellingLiabilities: String
 )
 
+@Deprecated("Formatted classes are to be removed")
 data class FormattedBalances(
   val assets: MutableList<FormattedAsset>,
   val liquidityPools: MutableList<FormattedLiquidityPool>
 )
 
+@Deprecated("Formatted classes are to be removed")
 data class FormattedLiquidityPool(
   val id: String,
   val balance: String,
@@ -73,12 +79,14 @@ enum class Order(internal val builderEnum: RequestBuilder.Order) {
   DESC(RequestBuilder.Order.DESC)
 }
 
+@Deprecated("Formatted classes are to be removed")
 data class LiquidityPoolInfo(
   val totalTrustlines: Long,
   val totalShares: String,
   val reserves: MutableList<LiquidityPoolReserve>
 )
 
+@Deprecated("Formatted classes are to be removed")
 data class LiquidityPoolReserve(
   val id: String,
   val assetCode: String,
@@ -89,6 +97,7 @@ data class LiquidityPoolReserve(
   val amount: String,
 )
 
+@Deprecated("Formatted classes are to be removed")
 data class NativeAssetDefault(
   val id: String,
   val homeDomain: String?,
@@ -98,6 +107,7 @@ data class NativeAssetDefault(
   val assetIssuer: String,
 )
 
+@Deprecated("Formatted classes are to be removed. Use rawOperation instead", replaceWith = ReplaceWith("this.rawOperation"))
 data class WalletOperation<T>(
   val id: String,
   val date: String,
@@ -108,6 +118,7 @@ data class WalletOperation<T>(
   val rawOperation: T,
 )
 
+@Deprecated("Formatted classes are to be removed")
 enum class WalletOperationType {
   SEND,
   RECEIVE,

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/extension/Server.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/extension/Server.kt
@@ -53,6 +53,7 @@ suspend fun Server.accountOrNull(accountAddress: String): AccountResponse? {
  * @return liquidity pool data object
  * @throws [HorizonRequestFailedException] for Horizon exceptions
  */
+@Deprecated("Formatted classes are to be removed")
 suspend fun Server.liquidityPoolInfo(
   liquidityPoolId: LiquidityPoolID,
   cachedAssetInfo: MutableMap<String, CachedAsset>

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/util/Format.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/util/Format.kt
@@ -25,6 +25,7 @@ import org.stellar.walletsdk.extension.reservedBalance
  * @return formatted account balances
  */
 @Suppress("LongMethod")
+@Deprecated("Formatted classes are to be removed")
 suspend fun formatAccountBalances(account: AccountResponse, server: Server): FormattedBalances {
   val cachedAssetTomlInfo = mutableMapOf<String, CachedAsset>()
 
@@ -140,6 +141,7 @@ suspend fun formatAccountBalances(account: AccountResponse, server: Server): For
  * @return formatted operation
  */
 @Suppress("ReturnCount")
+@Deprecated("Formatted classes are to be removed")
 fun formatStellarOperation(
   accountAddress: String,
   operation: OperationResponse
@@ -216,6 +218,7 @@ fun formatStellarOperation(
  *
  * @param T type of operation or transaction
  */
+@Deprecated("Formatted classes are to be removed")
 internal class WalletOperationBuilder<T : Any> {
   lateinit var id: String
   lateinit var date: String


### PR DESCRIPTION
Deprecates classes that wraps Horizon responses to be more UI-friendly.
We should let developers handle such logic themself for now.