### PR TITLE
Fix NPE

### DIFF
--- a/examples/SEP-24/src/main/kotlin/org/stellar/example/Main.kt
+++ b/examples/SEP-24/src/main/kotlin/org/stellar/example/Main.kt
@@ -109,7 +109,7 @@ suspend fun main() {
 
   // Send transaction with transfer
   val t = (transaction as WithdrawalTransaction)
-  val transfer = stellar.transaction(t.from).transferWithdrawalTransaction(t, asset).build()
+  val transfer = stellar.transaction(keypair).transferWithdrawalTransaction(t, asset).build()
 
   transfer.sign(keypair)
 

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/anchor/AnchorTransaction.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/anchor/AnchorTransaction.kt
@@ -6,7 +6,6 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.serializers.InstantIso8601Serializer
 import kotlinx.serialization.*
 import org.stellar.walletsdk.horizon.PublicKeyPair
-import org.stellar.walletsdk.json.AccountAsStringSerializer
 import org.stellar.walletsdk.json.AnchorTransactionSerializer
 import org.stellar.walletsdk.json.NullableAccountAsStringSerializer
 
@@ -81,7 +80,7 @@ data class WithdrawalTransaction(
   @SerialName("external_transaction_id") override val externalTransactionId: String? = null,
   override val message: String? = null,
   override val refunds: Refunds? = null,
-  @Serializable(with = AccountAsStringSerializer::class) val from: PublicKeyPair,
+  val from: PublicKeyPair? = null,
   val to: PublicKeyPair? = null,
   @SerialName("withdraw_memo") val withdrawalMemo: String? = null,
   @SerialName("withdraw_memo_type") val withdrawalMemoType: MemoType,

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/horizon/transaction/TransactionBuilder.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/horizon/transaction/TransactionBuilder.kt
@@ -147,7 +147,11 @@ suspend fun WithdrawalTransaction.toStellarTransfer(
 
   return stellar
     .transaction(
-      sourceAddress ?: this.from,
+      sourceAddress
+        ?: this.from
+          ?: throw ValidationException(
+          "Source account is not provided and from account is unknown"
+        ),
       memo = this.withdrawalMemo?.let { this.withdrawalMemoType to it }
           ?: throw ValidationException("Missing withdrawal_memo in the transaction")
     )


### PR DESCRIPTION
If anchor doesn't provide `from` field of a withdrawal transaction, NPE will be thrown.
This PR fixes it.