### PR TITLE
Deprecate getHistory

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Maven:
 <dependency>
   <groupId>org.stellar</groupId>
   <artifactId>wallet-sdk</artifactId>
-  <version>0.9.0</version>
+  <version>0.9.1</version>
 </dependency>
 ```
 
 Gradle:
 
 ```gradle
-implementation("org.stellar:wallet-sdk:0.9.0")
+implementation("org.stellar:wallet-sdk:0.9.1")
 ```
 
 ## Introduction

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ val jvmVersion = JavaVersion.VERSION_1_8
 
 allprojects {
   group = "org.stellar.wallet-sdk"
-  version = "0.9.0"
+  version = "0.9.1"
 }
 
 subprojects {

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/anchor/Sep24.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/anchor/Sep24.kt
@@ -222,6 +222,7 @@ internal constructor(
    * @throws [AssetNotSupportedException] if asset is not supported by the anchor
    */
   @Suppress("LongParameterList")
+  @Deprecated("Use getTransactionsForAsset instead")
   suspend fun getHistory(
     assetId: AssetId,
     authToken: AuthToken,


### PR DESCRIPTION
getTransactionsForAsset should be used instead (it's more flexible) 