### PR TITLE
Fix json error not being deserialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Maven:
 <dependency>
   <groupId>org.stellar</groupId>
   <artifactId>wallet-sdk</artifactId>
-  <version>0.9.1</version>
+  <version>0.9.2</version>
 </dependency>
 ```
 
 Gradle:
 
 ```gradle
-implementation("org.stellar:wallet-sdk:0.9.1")
+implementation("org.stellar:wallet-sdk:0.9.2")
 ```
 
 ## Introduction

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ val jvmVersion = JavaVersion.VERSION_1_8
 
 allprojects {
   group = "org.stellar.wallet-sdk"
-  version = "0.9.1"
+  version = "0.9.2"
 }
 
 subprojects {

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/auth/Sep10.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/auth/Sep10.kt
@@ -12,6 +12,7 @@ import org.stellar.sdk.Transaction
 import org.stellar.walletsdk.Config
 import org.stellar.walletsdk.exception.*
 import org.stellar.walletsdk.horizon.AccountKeyPair
+import org.stellar.walletsdk.util.Util.authGet
 import org.stellar.walletsdk.util.Util.postJson
 
 private val log = KotlinLogging.logger {}
@@ -91,7 +92,7 @@ internal constructor(
       "Challenge request: account = $account, memo = $memoId, client_domain = $clientDomain"
     }
 
-    val jsonResponse = httpClient.get(url.build()).body<ChallengeResponse>()
+    val jsonResponse = httpClient.authGet<ChallengeResponse>(url.build().toString())
 
     if (jsonResponse.transaction.isBlank()) {
       throw MissingTransactionException

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/auth/WalletSigner.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/auth/WalletSigner.kt
@@ -14,6 +14,7 @@ import org.stellar.walletsdk.horizon.AccountKeyPair
 import org.stellar.walletsdk.horizon.PublicKeyPair
 import org.stellar.walletsdk.horizon.SigningKeyPair
 import org.stellar.walletsdk.horizon.sign
+import org.stellar.walletsdk.util.Util.postJson
 
 /** Interface to provide wallet signer methods. */
 interface WalletSigner {
@@ -50,7 +51,7 @@ interface WalletSigner {
    * @constructor Create empty Json http signer
    * @property url url to which requests should be made
    * @property requestTransformer optional transformer of the default request. Can be used for
-   * authentication purposes, etc.
+   *   authentication purposes, etc.
    */
   class DomainSigner(val url: String, val requestTransformer: HttpRequestBuilder.() -> Unit = {}) :
     DefaultSigner() {
@@ -68,13 +69,9 @@ interface WalletSigner {
       account: AccountKeyPair
     ): Transaction {
       val response: SigningData =
-        client
-          .post(url) {
-            contentType(ContentType.Application.Json)
-            setBody(SigningData(transactionXDR, networkPassPhrase))
-            requestTransformer()
-          }
-          .body()
+        client.postJson(url, SigningData(transactionXDR, networkPassPhrase)) {
+          requestTransformer()
+        }
 
       return Transaction.fromEnvelopeXdr(response.transaction, Network(networkPassPhrase))
         as Transaction

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/util/Util.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/util/Util.kt
@@ -39,7 +39,7 @@ internal object Util {
 
   internal suspend inline fun <reified T> HttpClient.authGet(
     url: String,
-    authToken: AuthToken?,
+    authToken: AuthToken? = null,
   ): T {
     val textBody =
       this.get(url) {


### PR DESCRIPTION
Helper methods should be used instead of plain `.get()` `.post()` (helper methods deserialize errors)