### PR TITLE
Add `transaction_id` to SEP-12 requests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ val jvmVersion = JavaVersion.VERSION_11
 
 allprojects {
   group = "org.stellar.wallet-sdk"
-  version = "1.6.0"
+  version = "1.7.0-SNAPSHOT"
 }
 
 subprojects {

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/customer/Sep12.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/customer/Sep12.kt
@@ -25,6 +25,7 @@ internal constructor(
    * memo is present in the decoded SEP-10 JWT's sub value, it must match this parameter value.
    * @param type (optional) the type of action the customer is being KYCd for.
    * @param lang (optional) Defaults to en. Language code specified using ISO 639-1. Human-readable
+   * @param transactionId (optional) the ID of the transaction that the customer is being KYC'ed for.
    * descriptions, choices, and messages should be in this language.
    * @return a customer data object
    */
@@ -33,6 +34,7 @@ internal constructor(
     memo: ULong? = null,
     type: String? = null,
     lang: String? = null,
+    transactionId: String? = null,
   ): GetCustomerResponse {
     validateMemo(memo)
 
@@ -42,6 +44,7 @@ internal constructor(
     urlBuilder.addParameter("memo", memo?.toString())
     urlBuilder.addParameter("type", type)
     urlBuilder.addParameter("lang", lang)
+    urlBuilder.addParameter("transaction_id", transactionId)
     val urlString = urlBuilder.buildString()
 
     val response = httpClient.authGet<GetCustomerResponse>(urlString, token)
@@ -69,12 +72,14 @@ internal constructor(
    * @param memo (optional) the client-generated memo of type ID that uniquely identifies the
    * customer. If a memo is present in the decoded SEP-10 JWT's sub value, it must match this
    * parameter value.
+   * @param transactionId (optional) the ID of the transaction that the customer is being KYC'ed for.
    * @return a customer with id information
    */
   suspend fun add(
     sep9Info: Map<String, String>,
     memo: ULong? = null,
     type: String? = null,
+    transactionId : String? = null,
   ): AddCustomerResponse {
     val customer: MutableMap<String, String> = mutableMapOf()
 
@@ -82,6 +87,7 @@ internal constructor(
 
     val urlBuilder = URLBuilder(baseUrl)
     urlBuilder.appendPathSegments("customer")
+    urlBuilder.addParameter("transaction_id", transactionId)
     val urlString = urlBuilder.buildString()
 
     return httpClient.putJson(urlString, customer.toMap(), token)
@@ -98,6 +104,7 @@ internal constructor(
    * @param memo (optional) the client-generated memo of type ID that uniquely identifies the
    * customer. If a memo is present in the decoded SEP-10 JWT's sub value, it must match this
    * parameter value.
+   * @param transactionId (optional) the ID of the transaction that the customer is being KYC'ed for.
    * @return a customer with id information
    */
   suspend fun update(
@@ -105,6 +112,7 @@ internal constructor(
     id: String,
     type: String? = null,
     memo: ULong? = null,
+    transactionId: String? = null,
   ): AddCustomerResponse {
     val customer: MutableMap<String, String> = mutableMapOf("id" to id)
 
@@ -116,6 +124,7 @@ internal constructor(
 
     val urlBuilder = URLBuilder(baseUrl)
     urlBuilder.appendPathSegments("customer")
+    urlBuilder.addParameter("transaction_id", transactionId)
     val urlString = urlBuilder.buildString()
 
     return httpClient.putJson(urlString, customer.toMap(), token)

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/customer/Sep12.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/customer/Sep12.kt
@@ -25,8 +25,9 @@ internal constructor(
    * memo is present in the decoded SEP-10 JWT's sub value, it must match this parameter value.
    * @param type (optional) the type of action the customer is being KYCd for.
    * @param lang (optional) Defaults to en. Language code specified using ISO 639-1. Human-readable
-   * @param transactionId (optional) the ID of the transaction that the customer is being KYC'ed for.
    * descriptions, choices, and messages should be in this language.
+   * @param transactionId (optional) the ID of the transaction that the customer is being KYC'ed
+   * for.
    * @return a customer data object
    */
   suspend fun get(
@@ -72,14 +73,15 @@ internal constructor(
    * @param memo (optional) the client-generated memo of type ID that uniquely identifies the
    * customer. If a memo is present in the decoded SEP-10 JWT's sub value, it must match this
    * parameter value.
-   * @param transactionId (optional) the ID of the transaction that the customer is being KYC'ed for.
+   * @param transactionId (optional) the ID of the transaction that the customer is being KYC'ed
+   * for.
    * @return a customer with id information
    */
   suspend fun add(
     sep9Info: Map<String, String>,
     memo: ULong? = null,
     type: String? = null,
-    transactionId : String? = null,
+    transactionId: String? = null,
   ): AddCustomerResponse {
     val customer: MutableMap<String, String> = mutableMapOf()
 
@@ -104,7 +106,8 @@ internal constructor(
    * @param memo (optional) the client-generated memo of type ID that uniquely identifies the
    * customer. If a memo is present in the decoded SEP-10 JWT's sub value, it must match this
    * parameter value.
-   * @param transactionId (optional) the ID of the transaction that the customer is being KYC'ed for.
+   * @param transactionId (optional) the ID of the transaction that the customer is being KYC'ed
+   * for.
    * @return a customer with id information
    */
   suspend fun update(


### PR DESCRIPTION
This is to support the latest version of the SEP-12 protocol. Tests have not been added because the test anchor does not support the `transaction_id` fields.