### PR TITLE
Make `withdraw_anchor_account` optional

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ val jvmVersion = JavaVersion.VERSION_11
 
 allprojects {
   group = "org.stellar.wallet-sdk"
-  version = "1.7.0"
+  version = "1.7.1-SNAPSHOT"
 }
 
 subprojects {

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/anchor/AnchorTransaction.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/anchor/AnchorTransaction.kt
@@ -92,7 +92,7 @@ data class WithdrawalTransaction(
   val to: PublicKeyPair? = null,
   @SerialName("withdraw_memo") val withdrawalMemo: String? = null,
   @SerialName("withdraw_memo_type") val withdrawalMemoType: MemoType,
-  @SerialName("withdraw_anchor_account") val withdrawAnchorAccount: String
+  @SerialName("withdraw_anchor_account") val withdrawAnchorAccount: String? = null
 ) : ProcessingAnchorTransaction
 
 @Serializable

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/horizon/transaction/TransactionBuilder.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/horizon/transaction/TransactionBuilder.kt
@@ -1,18 +1,19 @@
 package org.stellar.walletsdk.horizon.transaction
 
 import org.stellar.sdk.*
-import org.stellar.sdk.TransactionBuilder as SdkBuilder
 import org.stellar.sdk.responses.AccountResponse
-import org.stellar.walletsdk.*
+import org.stellar.walletsdk.Config
 import org.stellar.walletsdk.anchor.MemoType
 import org.stellar.walletsdk.anchor.TransactionStatus
 import org.stellar.walletsdk.anchor.WithdrawalTransaction
 import org.stellar.walletsdk.asset.StellarAssetId
 import org.stellar.walletsdk.asset.toAsset
-import org.stellar.walletsdk.exception.*
-import org.stellar.walletsdk.extension.*
+import org.stellar.walletsdk.exception.InvalidStartingBalanceException
+import org.stellar.walletsdk.exception.ValidationException
 import org.stellar.walletsdk.horizon.AccountKeyPair
-import org.stellar.walletsdk.util.*
+import org.stellar.walletsdk.util.requireStatus
+import org.stellar.walletsdk.util.toTimeBounds
+import org.stellar.sdk.TransactionBuilder as SdkBuilder
 
 /** Class that allows to construct Stellar transactions, containing one or more operations */
 @Suppress("TooManyFunctions")
@@ -135,6 +136,11 @@ internal constructor(
         transaction.withdrawalMemo?.let { transaction.withdrawalMemoType to it }
           ?: throw ValidationException("Missing withdrawal_memo in the transaction")
       )
-      .transfer(transaction.withdrawAnchorAccount, assetId, transaction.amountIn)
+      .transfer(
+        transaction.withdrawAnchorAccount
+          ?: throw ValidationException("missing withdraw_anchor_account in the transaction"),
+        assetId,
+        transaction.amountIn
+      )
   }
 }


### PR DESCRIPTION
This field is optional at transaction creation but is required when the status becomes `PENDING_USER_TRANSFER_START`.