### PR TITLE
Set transaction_id in SEP-12 PUT body

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ val jvmVersion = JavaVersion.VERSION_11
 
 allprojects {
   group = "org.stellar.wallet-sdk"
-  version = "1.7.1"
+  version = "1.7.2"
 }
 
 subprojects {

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/customer/Sep12.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/customer/Sep12.kt
@@ -85,11 +85,10 @@ internal constructor(
   ): AddCustomerResponse {
     val customer: MutableMap<String, String> = mutableMapOf()
 
-    populateMap(type, customer, memo, sep9Info)
+    populateMap(type, transactionId, customer, memo, sep9Info)
 
     val urlBuilder = URLBuilder(baseUrl)
     urlBuilder.appendPathSegments("customer")
-    urlBuilder.addParameter("transaction_id", transactionId)
     val urlString = urlBuilder.buildString()
 
     return httpClient.putJson(urlString, customer.toMap(), token)
@@ -123,11 +122,10 @@ internal constructor(
       throw CustomerUpdateException()
     }
 
-    populateMap(type, customer, memo, sep9Info)
+    populateMap(type, transactionId, customer, memo, sep9Info)
 
     val urlBuilder = URLBuilder(baseUrl)
     urlBuilder.appendPathSegments("customer")
-    urlBuilder.addParameter("transaction_id", transactionId)
     val urlString = urlBuilder.buildString()
 
     return httpClient.putJson(urlString, customer.toMap(), token)
@@ -135,12 +133,16 @@ internal constructor(
 
   private fun populateMap(
     type: String?,
+    transactionId: String?,
     customer: MutableMap<String, String>,
     memo: ULong?,
     sep9Info: Map<String, String>
   ) {
     if (type != null) {
       customer["type"] = type
+    }
+    if (transactionId != null) {
+      customer["transaction_id"] = transactionId
     }
     validateMemo(memo) { customer["memo"] = it.toString() }
 


### PR DESCRIPTION
This sets the `transaction_id` in the SEP-12 `PUT /customer`'s request body instead of the request path. The reason why Anchor Platform tests were passing was because it was ignoring the `transaction_id` on the PUT path.