### PR TITLE
Improve logging hygiene in anchor response handling

### DIFF
--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/exception/ValidationExceptions.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/exception/ValidationExceptions.kt
@@ -33,8 +33,8 @@ object NetworkMismatchException : InvalidResponseException("Networks don't match
 
 class InvalidDataException(message: String) : InvalidResponseException(message)
 
-class InvalidJsonException(reason: String, json: Any) :
-  InvalidResponseException("Invalid json response object: $reason. Json: $json")
+class InvalidJsonException(reason: String) :
+  InvalidResponseException("Invalid json response object: $reason")
 
 class InvalidChallengeException(message: String) :
   ValidationException("Invalid SEP-10 challenge: $message")

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/json/AnchorDeserializers.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/json/AnchorDeserializers.kt
@@ -40,12 +40,12 @@ internal object AnchorTransactionSerializer :
               else -> DepositTransaction.serializer()
             }
           }
-          else -> throw InvalidJsonException("invalid kind", element)
+          else -> throw InvalidJsonException("invalid kind")
         }
       }
-      throw InvalidJsonException("status not found", element)
+      throw InvalidJsonException("status not found")
     }
-    throw InvalidJsonException("kind not found", element)
+    throw InvalidJsonException("kind not found")
   }
 }
 

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/json/Json.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/json/Json.kt
@@ -3,15 +3,11 @@ package org.stellar.walletsdk.json
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import mu.KotlinLogging
 import okhttp3.Response
-
-private val log = KotlinLogging.logger {}
 
 internal val defaultJson = Json { ignoreUnknownKeys = true }
 
 internal inline fun <reified T> String.fromJson(format: Json = defaultJson): T {
-  log.trace { "JSON format: $this" }
   return format.decodeFromString(this)
 }
 

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/util/Util.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/util/Util.kt
@@ -164,14 +164,14 @@ fun String.toAssetId(): AssetId {
 
     // scheme:code:issuer
     if (split.size != 3) {
-      throw InvalidJsonException("Invalid asset format", str)
+      throw InvalidJsonException("Invalid asset format")
     }
 
     return IssuedAssetId(split[1], split[2])
   } else if (str.startsWith(FIAT_SCHEME)) {
     return FiatAssetId(str)
   }
-  throw InvalidJsonException("Unknown scheme", str)
+  throw InvalidJsonException("Unknown scheme")
 }
 
 fun SigningKeyPair.toJava(): java.security.KeyPair {

--- a/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/util/Util.kt
+++ b/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/util/Util.kt
@@ -70,7 +70,7 @@ internal object Util {
         }
         .bodyAsText()
 
-    log.debug { "Received $url response $textBody" }
+    log.debug { "Received response from $url" }
 
     return textBody.fromJsonOrError()
   }
@@ -140,7 +140,7 @@ internal object Util {
         throw AnchorRequestException(error.error, e)
       } catch (ignored: SerializationException) {}
 
-      throw AnchorRequestException("Failed to deserialize string: $this", e)
+      throw AnchorRequestException("Failed to deserialize anchor response", e)
     }
   }
 }

--- a/wallet-sdk/src/test/kotlin/org/stellar/walletsdk/util/DeserializeAnchorTransactionTest.kt
+++ b/wallet-sdk/src/test/kotlin/org/stellar/walletsdk/util/DeserializeAnchorTransactionTest.kt
@@ -1,10 +1,14 @@
 package org.stellar.walletsdk.util
 
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Test
 import org.stellar.walletsdk.anchor.*
+import org.stellar.walletsdk.exception.InvalidJsonException
 import org.stellar.walletsdk.helpers.sdkObjectFromJsonFile
+import org.stellar.walletsdk.json.fromJson
 
 @Serializable
 data class AnchorTransactionsJson(
@@ -36,5 +40,48 @@ internal class DeserializeAnchorTransactionTest {
   @Test
   fun `incomplete withdrawal`() {
     assertIs<IncompleteWithdrawalTransaction>(anchorTransactions.incompleteWithdrawal)
+  }
+
+  @Test
+  fun `missing kind does not leak response body in exception message`() {
+    val sensitive = "eyJ.SENSITIVE_TOKEN_PAYLOAD.SIGNATURE"
+    val payload =
+      """{"status": "completed", "more_info_url": "https://anchor.example/?token=$sensitive"}"""
+
+    val ex = assertFailsWith<InvalidJsonException> { payload.fromJson<AnchorTransaction>() }
+
+    val message = ex.message ?: ""
+    assertFalse(
+      message.contains(sensitive),
+      "exception message must not leak response body; got: $message"
+    )
+  }
+
+  @Test
+  fun `missing status does not leak response body in exception message`() {
+    val sensitive = "FIRST_NAME=Alice;LAST_NAME=Smith;DOB=1990-01-01"
+    val payload = """{"kind": "deposit", "metadata": "$sensitive"}"""
+
+    val ex = assertFailsWith<InvalidJsonException> { payload.fromJson<AnchorTransaction>() }
+
+    val message = ex.message ?: ""
+    assertFalse(
+      message.contains(sensitive),
+      "exception message must not leak response body; got: $message"
+    )
+  }
+
+  @Test
+  fun `invalid kind value does not leak response body in exception message`() {
+    val sensitive = "another_secret_value_12345"
+    val payload = """{"kind": "bogus", "status": "completed", "memo": "$sensitive"}"""
+
+    val ex = assertFailsWith<InvalidJsonException> { payload.fromJson<AnchorTransaction>() }
+
+    val message = ex.message ?: ""
+    assertFalse(
+      message.contains(sensitive),
+      "exception message must not leak response body; got: $message"
+    )
   }
 }

--- a/wallet-sdk/src/test/kotlin/org/stellar/walletsdk/util/FromJsonOrErrorTest.kt
+++ b/wallet-sdk/src/test/kotlin/org/stellar/walletsdk/util/FromJsonOrErrorTest.kt
@@ -1,0 +1,79 @@
+package org.stellar.walletsdk.util
+
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.utils.io.*
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
+import org.junit.jupiter.api.Test
+import org.stellar.walletsdk.exception.AnchorRequestException
+import org.stellar.walletsdk.util.Util.postJson
+
+@Serializable internal data class DummyRequest(val foo: String)
+
+@Serializable internal data class DummyResponse(val bar: String)
+
+internal class FromJsonOrErrorTest {
+
+  private fun clientReturning(
+    body: String,
+    status: HttpStatusCode = HttpStatusCode.OK
+  ): HttpClient {
+    val engine = MockEngine { _ ->
+      respond(
+        content = ByteReadChannel(body),
+        status = status,
+        headers = headersOf(HttpHeaders.ContentType, "application/json")
+      )
+    }
+    return HttpClient(engine) { install(ContentNegotiation) { json() } }
+  }
+
+  @Test
+  fun `exception message does not include raw response body when JSON is malformed`() {
+    val sensitiveToken = "eyJ.VALID_TOKEN_PAYLOAD.SIGNATURE"
+    val malformedBody = """{"token": "$sensitiveToken", "malformed_field": }"""
+    val client = clientReturning(malformedBody)
+
+    val ex =
+      assertFailsWith<AnchorRequestException> {
+        runBlocking {
+          client.postJson<DummyRequest, DummyResponse>("https://example.com", DummyRequest("x"))
+        }
+      }
+
+    val message = ex.message ?: ""
+    assertFalse(
+      message.contains(sensitiveToken),
+      "exception message must not leak the response body; got: $message"
+    )
+    assertFalse(
+      message.contains(malformedBody),
+      "exception message must not leak the raw response body; got: $message"
+    )
+  }
+
+  @Test
+  fun `anchor error responses still surface the server-provided error`() {
+    val errorBody = """{"error": "user not eligible"}"""
+    val client = clientReturning(errorBody, HttpStatusCode.BadRequest)
+
+    val ex =
+      assertFailsWith<AnchorRequestException> {
+        runBlocking {
+          client.postJson<DummyRequest, DummyResponse>("https://example.com", DummyRequest("x"))
+        }
+      }
+
+    assertTrue(
+      (ex.message ?: "").contains("user not eligible"),
+      "anchor error message should be propagated; got: ${ex.message}"
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- Stops embedding raw HTTP response bodies in exception messages and debug log statements across the anchor response paths (`fromJsonOrError`, `authGetStringToken`, `InvalidJsonException`, the `AnchorTransactionSerializer` failure paths, and `String.toAssetId`).
- `InvalidJsonException` no longer takes a `json: Any` constructor parameter; the message is built from the reason alone. All four call sites updated.
- Removes the per-deserialize trace log in `Json.fromJson` that printed the full JSON payload on every call.
- Cause exceptions are still preserved so the underlying parser diagnostics remain available in stack traces.

## Test plan

- [x] New `FromJsonOrErrorTest` covers the malformed-response and `AnchorErrorResponse` paths through `postJson`.
- [x] New regression cases in `DeserializeAnchorTransactionTest` cover the missing-`kind`, missing-`status`, and invalid-`kind` failure paths in `AnchorTransactionSerializer`. Each plants a marker string in the payload and asserts the marker does not appear in the resulting exception message. All three failed before the fix and pass after.
- [x] `./gradlew :wallet-sdk:test` — 78 tests, 63 passing. The 15 failures are pre-existing network failures against `testanchor.stellar.org` (documented in `ci-failures.md`); same set fails on `main`.
- [x] `./gradlew :wallet-sdk:spotlessCheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)